### PR TITLE
fix: Add dynamic export for static site generation

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,5 +1,7 @@
 import { MetadataRoute } from 'next'
 
+export const dynamic = 'force-static'
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,8 @@
 import { MetadataRoute } from 'next'
 import { getAllPosts } from '@/lib/posts'
 
+export const dynamic = 'force-static'
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://iamanuragh.in'
 


### PR DESCRIPTION
Fixes build error when using `output: 'export'` in Next.js config.

Adds `export const dynamic = 'force-static'` to:
- `app/robots.ts`
- `app/sitemap.ts`

This is required for Next.js static exports to properly generate metadata route handlers at build time.

Related to #4

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kpanuragh/kpanuragh.github.io/actions/runs/21257257173) | [Branch: claude/pr-4-20260122-1658](https://github.com/kpanuragh/kpanuragh.github.io/tree/claude/pr-4-20260122-1658